### PR TITLE
fix: convert string to int for correctly typed variables

### DIFF
--- a/starter_files/swagger/serve.py
+++ b/starter_files/swagger/serve.py
@@ -33,7 +33,7 @@ class CORSRequestHandler(SimpleHTTPRequestHandler):
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         # Allows the port to be passed in as an argument
-        port = sys.argv[-1]
+        port = int(sys.argv[-1])
     else:
         port = 8000
 


### PR DESCRIPTION
without this conversion, an error message saying the port variable has to be a number will appear.